### PR TITLE
increase cutoff energy and charge density values in graphene example

### DIFF
--- a/src/graphene/graphene_bands.in
+++ b/src/graphene/graphene_bands.in
@@ -11,8 +11,8 @@
     celldm(3) = 3.0,
     nat  = 2,
     ntyp = 1,
-    ecutwfc = 20.0,
-    ecutrho = 200.0,
+    ecutwfc = 40.0,
+    ecutrho = 400.0,
     nbnd=8
     !occupations = 'tetrahedra'
  /


### PR DESCRIPTION
Hello there is a problem with the ecutwfc value. I think, it shoulg be increased. Also I tried the lines of cade you gave for the pdos calculations, but it doesn't works for graphene and I dont really know why. I have a out of index error.

you really did a great job and this really helped me thanks a lot. Wah.