### PR TITLE
Bug in PDOS Calculation

### DIFF
--- a/docs/hands-on/pdos.mdx
+++ b/docs/hands-on/pdos.mdx
@@ -69,7 +69,7 @@ def data_loader(fname):
 
     data = np.loadtxt(fname)
     energy = data[:, 0]
-    pdos = data[:, 2]
+    pdos = data[:, 1]
 
     return energy, pdos
 


### PR DESCRIPTION
Previous code was only plotting the px-orbital contribution. Modification done will use the ldos data from the *.pdos* files. It will plot the total contribution from px, py, pz as desired in the plot. And for the case of total dos, it will take the dos column and for s orbital it wil take the ldos column. 